### PR TITLE
Google plus and syntax hightlighting

### DIFF
--- a/svbtletheme.html
+++ b/svbtletheme.html
@@ -44,6 +44,29 @@
         <!-- Facebook Open Graph -->
         <meta property="og:site_name" content="{Title}"/>
         
+        <!-- For Syntax Highlighting -->
+        <script src="http://code.jquery.com/jquery-latest.min.js"></script>
+        <link rel="stylesheet" type="text/css" href="http://google-code-prettify.googlecode.com/svn/trunk/src/prettify.css"></link>  
+        <script src="http://google-code-prettify.googlecode.com/svn/trunk/src/prettify.js"></script>  
+        <script>
+            function styleCode() {
+                if (typeof disableStyleCode != 'undefined') { return; }
+        
+                var a = false;
+                
+                $('code').each(function() {
+                    if (!$(this).hasClass('prettyprint') && !$(this).hasClass('uglyprint')) {
+                        $(this).addClass('prettyprint');
+                        a = true;
+                    }
+                });
+        
+                if (a) { prettyPrint(); } 
+            }
+    
+            $(function() {styleCode();});
+        </script>
+        
         {block:PermalinkPage}
             <meta property="og:url" content="{Permalink}"/>
             <meta property="og:type" content="article"/>


### PR DESCRIPTION
Thanks for this excellent theme! Here are the modifications I made to it on my blog:

Adds google plus badge next to the Twitter and Facebook ones.

Tumblr posts, as far as I can tell, frequently use `<code>` tags within `<pre>` tags to denote code snippets. For `<code>` tags without the class `uglyprint` will use Google's prettify code.
