### PR TITLE
Notes, Tags and Visitor Feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,10 @@
-svbtle-tumblr-theme
-===================
+Svbtle Theme: Added Features
+============================
 
-<p>Svbtle Theme is a responsive Tumblr theme inspired by Svbtle, the invite-only publishing network.
-You can see a preview here: http://svbtletheme.tumblr.com</p>
-<ul>
-<li>Full documentation here: http://svbtletheme.tumblr.com/documentation</li>
-<li>Gallery of featured blogs here: http://svbtletheme.tumblr.com/tagged/gallery</li>
-</ul>
-<a href="http://svbtletheme.tumblr.com"><img src="https://dl.dropbox.com/u/2930775/matteoroversi.com/img/12.12.21_svbtle_theme.jpg"></a>
+<p>Code snippets for additional features in the Svbtle Theme. See Website for live example.</p>
 
-<h2>What’s new in version 1.1 (15/01/2013)</h2>
+<h2>Update Log</h2>
 <ul>
-<li>Disqus comments</li>
-<li>Facebook likes and Twitter shares</li>
-<li>Support for retina display</li>
-<li>Socialico font for social links</li>
-</ul>
-
-<h2>Main features (version 1.0 - 23/12/2012)</h2>
-<ul>
-<li>Responsive design: 3 different views for large desktops, laptops and tablets / mobile</li>
-<li>Custom Logo</li>
-<li>Custom navigation menu: includes custom pages, ask and submit pages (if enabled)</li>
-<li>Google web fonts</li>
-<li>Fluid embedded media: photos, videos, presentations</li>
-<li>Custom colors: sidebar, blog name, description, date, links, navigation, text</li>
-<li>Google Analytics ID</li>
+  <li>2014-11-17: Display tags on all post types</li>
+  <li>2015-02-06: Display # of notes as Thumb-ups, enable Like button on individual posts</li>
 </ul>

--- a/svbtletheme.html
+++ b/svbtletheme.html
@@ -690,7 +690,7 @@
                text-align: center;
             }
             <!-- End of Like button CSS -->
-            <!-- Thumb up/Notes CSS; remove and swap with Custom CSS if applicable -->
+            <!-- Notes CSS (Thumb-up visual format); remove and swap with Custom CSS if applicable -->
             #date span.yesnote {
               background: #eaeaea;
                color: #aaa;
@@ -699,7 +699,7 @@
               margin-left: 1em;
               padding: 1px 10px;
             }
-            <!-- End of Thumb up/Notes CSS -->
+            <!-- End of Notes CSS -->
         </style>
     </head>
     <body>

--- a/svbtletheme.html
+++ b/svbtletheme.html
@@ -37,24 +37,20 @@
         <meta name="if:Enable Comment Count" content="1" />
         <!-- For Syntax Highlighting -->
         <script src="http://code.jquery.com/jquery-latest.min.js"></script>
-        <link rel="stylesheet" type="text/css" href="http://google-code-prettify.googlecode.com/svn/trunk/src/prettify.css"></link>  
-        <script src="http://google-code-prettify.googlecode.com/svn/trunk/src/prettify.js"></script>  
+        <link rel="stylesheet" type="text/css" href="http://google-code-prettify.googlecode.com/svn/trunk/src/prettify.css"></link>
+        <script src="http://google-code-prettify.googlecode.com/svn/trunk/src/prettify.js"></script>
         <script>
             function styleCode() {
                 if (typeof disableStyleCode != 'undefined') { return; }
-        
                 var a = false;
-                
                 $('code').each(function() {
                     if (!$(this).hasClass('prettyprint') && !$(this).hasClass('uglyprint')) {
                         $(this).addClass('prettyprint');
                         a = true;
                     }
                 });
-        
-                if (a) { prettyPrint(); } 
+                if (a) { prettyPrint(); }
             }
-    
             $(function() {styleCode();});
         </script>
         <!-- Facebook Open Graph -->
@@ -123,7 +119,7 @@
             <meta property="og:type" content="blog"/>
             <meta property="og:description" content="{MetaDescription}"/>
             <meta property="og:image" content="{PortraitURL-128}"/>
-        {/block:IndexPage}        
+        {/block:IndexPage}
         <!-- CSS -->
         <style type="text/css">
             /* General Settings */
@@ -131,7 +127,7 @@
                 font-family: "PT Sans", sans-serif;
                 font-weight: 400;
                 -webkit-text-size-adjust: 100%;
-            	-ms-text-size-adjust: 100%;
+              -ms-text-size-adjust: 100%;
                 -webkit-font-smoothing: antialiased;
                 margin: 0 0 0 0;
             }
@@ -157,8 +153,8 @@
                 background-image: url("{image:Logo 200x200}");
                 background-size: 140px 140px;
                 background-repeat: no-repeat;
-        		background-color:transparent;
-    			background-position:center center;
+                background-color:transparent;
+                background-position:center center;
             }
             #sidebar .logo h1 {
                 text-transform: uppercase;
@@ -277,7 +273,7 @@
             }
             #post .text img a:hover {
                 text-decoration: none;
-            }   
+            }
             #post .text a, #post .text a:visited {
                 text-decoration: none;
                 font-weight: bold;
@@ -290,7 +286,7 @@
                 -o-transition: all 0.5s ease;
                 transition: all 0.5s ease;
                 color: #fff;
-                background-color: {color:Highlight Colour};  
+                background-color: {color:Highlight Colour};
             }
             #post .text h3 {
                 margin-top: 40px;
@@ -501,28 +497,28 @@
                     width: 400px;
                 }
                 #sidebar .logo .img {
-                	width: 200px;
-                	height: 200px;
-                	margin-left: 50px;
-                	background-size: 200px 200px;
+                  width: 200px;
+                  height: 200px;
+                  margin-left: 50px;
+                  background-size: 200px 200px;
                 }
                 #sidebar .logo h1 {
-                	font-size: 30px;
-                	margin-left: 50px;
+                  font-size: 30px;
+                  margin-left: 50px;
                     margin-right: 40px;
                     margin-bottom: 8px;
                 }
                 #sidebar .description {
-                	font-size: 18px;
-                	line-height: 26px;
-                	margin-left: 50px;
+                  font-size: 18px;
+                  line-height: 26px;
+                  margin-left: 50px;
                     margin-right: 40px;
                     margin-top: 0px;
                 }
                 #sidebar .navigation a {
-                	font-size: 18px;
-                	margin-top: 16px;
-                	margin-left: 38px;
+                  font-size: 18px;
+                  margin-top: 16px;
+                  margin-left: 38px;
                     padding: 12px;
                     padding-left: 24px;
                     padding-right: 24px;
@@ -530,39 +526,39 @@
                     border-color: #efefef;
                 }
                 #main {
-                	margin-left: 400px;
+                  margin-left: 400px;
                 }
                 #date {
                     padding-top: 50px;
                 }
                 #date a, #date a:visited {
-                	font-size: 16px;
-                	margin-left: 50px;
+                  font-size: 16px;
+                  margin-left: 50px;
                 }
                 #post {
-                	margin-left: 50px;
-                	margin-right: 50px;
-                	max-width: 900px;
+                  margin-left: 50px;
+                  margin-right: 50px;
+                  max-width: 900px;
                 }
                 #post .text {
-                	font-size: 18px;
-                	line-height: 26px;
+                  font-size: 18px;
+                  line-height: 26px;
                 }
                 #post .title {
-                	font-size: 26px;
+                  font-size: 26px;
                 }
                 #post .quote {
-                	font-size: 26px;
+                  font-size: 26px;
                 }
                 #post .audiocaption {
-                	font-size: 16px;
+                  font-size: 16px;
                 }
                 .social_links {
                 margin-left: 50px;
                 }
-                
+
                 #postfooter a, #postfooter a:visited {
-                	margin-left: 50px;
+                  margin-left: 50px;
                 }
                 #disqus_thread {
                     margin-left: 50px;
@@ -570,42 +566,42 @@
                     max-width: 900px;
                 }
                 #pagination .next {
-                	margin-right: 50px;
+                  margin-right: 50px;
                 }
                 #pagination .prev {
-                	margin-left: 50px;
+                  margin-left: 50px;
                 }
             }
             /* Tablets (Portrait) ----------- */
             @media only screen and (max-width: 800px) {
                 #sidebar {
                     display: block;
-                	height: auto;
-                	margin: 0;
-                	padding: 0;
+                  height: auto;
+                  margin: 0;
+                  padding: 0;
                     padding-bottom: 40px;
-                	position: relative;
-                	text-align: center;
-                	width: auto;
+                  position: relative;
+                  text-align: center;
+                  width: auto;
                 }
                 #sidebar .logo .img {
-                	margin-left: 0px;
+                  margin-left: 0px;
                     margin: 20px auto;
                 }
                 #sidebar .logo h1 {
-                	margin-left: 6%;
-                	margin-right: 6%;
+                  margin-left: 6%;
+                  margin-right: 6%;
                 }
                 #sidebar .description {
-                	margin-left: 6%;
-                	margin-right: 6%;
+                  margin-left: 6%;
+                  margin-right: 6%;
                 }
                 #sidebar .navigation {
-                	display: inline-block;
+                  display: inline-block;
                     width: 100%;
                 }
                 #sidebar .navigation a {
-                	margin-left: 2px;
+                  margin-left: 2px;
                     margin-right: 2px;
                 }
                 #main {
@@ -618,7 +614,7 @@
                     margin-left: 6%;
                 }
                 #post {
-                	margin-left: 6%;
+                  margin-left: 6%;
                     margin-right: 6%;
                     max-width: 768px;
                 }
@@ -626,7 +622,7 @@
                 margin-left: 6%;
                 }
                 #postfooter a, #postfooter a:visited {
-                	margin-left: 6%;
+                  margin-left: 6%;
                 }
                 #disqus_thread {
                     margin-left: 6%;
@@ -634,10 +630,10 @@
                     max-width: 768px;
                 }
                 #pagination .next {
-                	margin-right: 6%;
+                  margin-right: 6%;
                 }
                 #pagination .prev {
-                	margin-left: 6%;
+                  margin-left: 6%;
                 }
             }
             /* Tablets (Landscape) ----------- */
@@ -646,8 +642,8 @@
                     position: absolute;
                 }
             }
-            /* Retina Displays ----------- */ 
-            @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) { 
+            /* Retina Displays ----------- */
+            @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
                 #sidebar .logo .img {
                     background-image: url("{image:Logo Retina 400x400}");
                 }
@@ -660,9 +656,53 @@
         <!-- Custom CSS -->
         <style>
             {CustomCSS}
+
+            <!-- Tag row CSS; remove and swap with Custom CSS if applicable -->
+            div.alltags {
+              background: #efefef;
+              font: small-caps 0.8em/100% "PT Sans",sans-serif;
+              border-radius: 30px 0 0 30px;
+              margin: -1.5em 0 1.5em 40%;
+              padding: .6em 1em;
+            }
+            div.alltags a {
+              color: {color:Navigation Colour};
+              font-size: 1em;
+              padding: 0 .25em;
+            }
+            div.alltags a:hover {
+              color: {color:Text Colour};
+            }
+            <!-- End of tag row CSS -->
+            <!-- Like button CSS; remove and swap with Custom CSS if applicable -->
+            #date span.likeme {
+              float: right;
+              width: 3%;
+              background: #eaeaea;
+              border-radius: 15px 0 0 15px;
+              padding: .3em .5em 0 .8em;
+              opacity: .7;
+            }
+            #date span.likeme:hover {
+              opacity: 1;
+            }
+            #date .like_button {
+               text-align: center;
+            }
+            <!-- End of Like button CSS -->
+            <!-- Thumb up/Notes CSS; remove and swap with Custom CSS if applicable -->
+            #date span.yesnote {
+              background: #eaeaea;
+               color: #aaa;
+              font: small-caps 0.8em/100% 'Oxygen',sans-serif;
+              border-radius: 30px;
+              margin-left: 1em;
+              padding: 1px 10px;
+            }
+            <!-- End of Thumb up/Notes CSS -->
         </style>
     </head>
-    <body>        
+    <body>
         <!-- Facebook Script -->
         <div id="fb-root"></div>
         <script>(function(d, s, id) {
@@ -682,7 +722,7 @@
                 </a>
                 <a href="/" title="{Title}">
                     <h1>{Title}</h1>
-			    </a>
+          </a>
             </div>
             <!-- Description -->
             <div class="description">
@@ -699,17 +739,21 @@
         ---------------------------------->
         <div id="main">
         {block:Posts}
-            <!-- Photo -->   
+            <!-- Photo -->
             {block:Photo}
                 <div id="date">
                     <a href="{Permalink}">
                         {block:Date}{DayOfMonth} {Month} {Year}{/block:Date}
                     </a>
                     {block:IfEnableCommentCount}
-        				{block:IfDisqusShortname}
-						<a href="{Permalink}#disqus_thread">0 Comments</a>
-						{/block:IfDisqusShortname}
-					{/block:IfEnableCommentCount}
+                        {block:IfDisqusShortname}
+                              <a href="{Permalink}#disqus_thread">0 Comments</a>
+                        {/block:IfDisqusShortname}
+                    {/block:IfEnableCommentCount}
+                    {block:NoteCount}
+                        <span class="yesnote">{NoteCount} &#128077;</span>
+                    {/block:NoteCount}
+                    <span class="likeme">{LikeButton size="18"}</span>
                 </div>
                 <div id="post">
                     {LinkOpenTag}
@@ -718,7 +762,13 @@
                     {block:Caption}
                         <div class="text">{Caption}</div>
                     {/block:Caption}
-                </div>    
+                </div>
+                <div class="alltags">
+                    {block:HasTags}
+                      Tagged under
+                      {block:Tags}<a href="{TagURL}">#{Tag}</a>{/block:Tags}
+                    {/block:HasTags}
+                </div>
             {/block:Photo}
             <!-- Photoset -->
             {block:Photoset}
@@ -727,10 +777,14 @@
                         {block:Date}{DayOfMonth} {Month} {Year}{/block:Date}
                     </a>
                     {block:IfEnableCommentCount}
-        				{block:IfDisqusShortname}
-						<a href="{Permalink}#disqus_thread">0 Comments</a>
-						{/block:IfDisqusShortname}
-					{/block:IfEnableCommentCount}
+                        {block:IfDisqusShortname}
+                              <a href="{Permalink}#disqus_thread">0 Comments</a>
+                        {/block:IfDisqusShortname}
+                    {/block:IfEnableCommentCount}
+                    {block:NoteCount}
+                        <span class="yesnote">{NoteCount} &#128077;</span>
+                    {/block:NoteCount}
+                    <span class="likeme">{LikeButton size="18"}</span>
                 </div>
                 <div id="post">
                     <div class="photoset">
@@ -742,6 +796,12 @@
                         <div class="text">{Caption}</div>
                     {/block:Caption}
                 </div>
+                <div class="alltags">
+                    {block:HasTags}
+                      Tagged under
+                      {block:Tags}<a href="{TagURL}">#{Tag}</a>{/block:Tags}
+                    {/block:HasTags}
+                </div>
             {/block:Photoset}
             <!-- Video -->
             {block:Video}
@@ -750,10 +810,14 @@
                         {block:Date}{DayOfMonth} {Month} {Year}{/block:Date}
                     </a>
                     {block:IfEnableCommentCount}
-        				{block:IfDisqusShortname}
-						<a href="{Permalink}#disqus_thread">0 Comments</a>
-						{/block:IfDisqusShortname}
-					{/block:IfEnableCommentCount}
+                        {block:IfDisqusShortname}
+                              <a href="{Permalink}#disqus_thread">0 Comments</a>
+                        {/block:IfDisqusShortname}
+                    {/block:IfEnableCommentCount}
+                    {block:NoteCount}
+                        <span class="yesnote">{NoteCount} &#128077;</span>
+                    {/block:NoteCount}
+                    <span class="likeme">{LikeButton size="18"}</span>
                 </div>
                 <div id="post">
                     <p></p>
@@ -761,6 +825,12 @@
                     {block:Caption}
                         <div class="text">{Caption}</div>
                     {/block:Caption}
+                </div>
+                <div class="alltags">
+                    {block:HasTags}
+                      Tagged under
+                      {block:Tags}<a href="{TagURL}">#{Tag}</a>{/block:Tags}
+                    {/block:HasTags}
                 </div>
             {/block:Video}
             <!-- Audio -->
@@ -770,10 +840,14 @@
                         {block:Date}{DayOfMonth} {Month} {Year}{/block:Date}
                     </a>
                     {block:IfEnableCommentCount}
-        				{block:IfDisqusShortname}
-						<a href="{Permalink}#disqus_thread">0 Comments</a>
-						{/block:IfDisqusShortname}
-					{/block:IfEnableCommentCount}
+                        {block:IfDisqusShortname}
+                              <a href="{Permalink}#disqus_thread">0 Comments</a>
+                        {/block:IfDisqusShortname}
+                    {/block:IfEnableCommentCount}
+                    {block:NoteCount}
+                        <span class="yesnote">{NoteCount} &#128077;</span>
+                    {/block:NoteCount}
+                    <span class="likeme">{LikeButton size="18"}</span>
                 </div>
                 <div id="post">
                     <div class="audio">
@@ -783,7 +857,13 @@
                     {block:Caption}
                         <div class="text">{Caption}</div>
                     {/block:Caption}
-                </div>    
+                </div>
+                <div class="alltags">
+                    {block:HasTags}
+                      Tagged under
+                      {block:Tags}<a href="{TagURL}">#{Tag}</a>{/block:Tags}
+                    {/block:HasTags}
+                </div>
             {/block:Audio}
             <!-- Quote -->
             {block:Quote}
@@ -792,10 +872,14 @@
                         {block:Date}{DayOfMonth} {Month} {Year}{/block:Date}
                     </a>
                     {block:IfEnableCommentCount}
-        				{block:IfDisqusShortname}
-						<a href="{Permalink}#disqus_thread">0 Comments</a>
-						{/block:IfDisqusShortname}
-					{/block:IfEnableCommentCount}
+                        {block:IfDisqusShortname}
+                              <a href="{Permalink}#disqus_thread">0 Comments</a>
+                        {/block:IfDisqusShortname}
+                    {/block:IfEnableCommentCount}
+                    {block:NoteCount}
+                        <span class="yesnote">{NoteCount} &#128077;</span>
+                    {/block:NoteCount}
+                    <span class="likeme">{LikeButton size="18"}</span>
                 </div>
                 <div id="post">
                     <a href="{Permalink}">
@@ -804,7 +888,13 @@
                     {block:Source}
                         <div class="text"><p>{Source}</p></div>
                     {/block:Source}
-                </div>            
+                </div>
+                <div class="alltags">
+                    {block:HasTags}
+                      Tagged under
+                      {block:Tags}<a href="{TagURL}">#{Tag}</a>{/block:Tags}
+                    {/block:HasTags}
+                </div>
             {/block:Quote}
             <!-- Text -->
             {block:Text}
@@ -814,18 +904,22 @@
                     </a>
                     {block:IndexPage}
                     {block:IfEnableCommentCount}
-        				{block:IfDisqusShortname}
-						<a href="{Permalink}#disqus_thread">0 Comments</a>
-						{/block:IfDisqusShortname}
-					{/block:IfEnableCommentCount}
+                        {block:IfDisqusShortname}
+                              <a href="{Permalink}#disqus_thread">0 Comments</a>
+                        {/block:IfDisqusShortname}
+                    {/block:IfEnableCommentCount}
                     {/block:IndexPage}
                     {block:PermalinkPagination}
-                    {block:IfEnableCommentCount}
-            			{block:IfDisqusShortname}
-						<a href="{Permalink}#disqus_thread">0 Comments</a>
-						{/block:IfDisqusShortname}
-					{/block:IfEnableCommentCount}
+                      {block:IfEnableCommentCount}
+                         {block:IfDisqusShortname}
+                               <a href="{Permalink}#disqus_thread">0 Comments</a>
+                         {/block:IfDisqusShortname}
+                      {/block:IfEnableCommentCount}
                     {/block:PermalinkPagination}
+                    {block:NoteCount}
+                        <span class="yesnote">{NoteCount} &#128077;</span>
+                    {/block:NoteCount}
+                    <span class="likeme">{LikeButton size="18"}</span>
                 </div>
                 <div id="post">
                     <a href="{Permalink}">
@@ -835,6 +929,12 @@
                     </a>
                     <div class="text">{Body}</div>
                 </div>
+                <div class="alltags">
+                    {block:HasTags}
+                      Tagged under
+                      {block:Tags}<a href="{TagURL}">#{Tag}</a>{/block:Tags}
+                    {/block:HasTags}
+                </div>
             {/block:Text}
             <!-- Answer -->
             {block:Answer}
@@ -842,6 +942,10 @@
                     <a href="{Permalink}">
                         {block:Date}{DayOfMonth} {Month} {Year}{/block:Date}
                     </a>
+                    {block:NoteCount}
+                        <span class="yesnote">{NoteCount} &#128077;</span>
+                    {/block:NoteCount}
+                    <span class="likeme">{LikeButton size="18"}</span>
                 </div>
                 <div id="post">
                     <a href="{Permalink}">
@@ -849,6 +953,12 @@
                     </a>
                     <div class="text">{Asker}</div>
                     <div class="text">{Answer}</div>
+                </div>
+                <div class="alltags">
+                    {block:HasTags}
+                      Tagged under
+                      {block:Tags}<a href="{TagURL}">#{Tag}</a>{/block:Tags}
+                    {/block:HasTags}
                 </div>
             {/block:Answer}
             <!-- Chat -->
@@ -858,10 +968,14 @@
                         {block:Date}{DayOfMonth} {Month} {Year}{/block:Date}
                     </a>
                     {block:IfEnableCommentCount}
-        				{block:IfDisqusShortname}
-						<a href="{Permalink}#disqus_thread">0 Comments</a>
-						{/block:IfDisqusShortname}
-					{/block:IfEnableCommentCount}
+                        {block:IfDisqusShortname}
+                              <a href="{Permalink}#disqus_thread">0 Comments</a>
+                        {/block:IfDisqusShortname}
+                    {/block:IfEnableCommentCount}
+                    {block:NoteCount}
+                        <span class="yesnote">{NoteCount} &#128077;</span>
+                    {/block:NoteCount}
+                    <span class="likeme">{LikeButton size="18"}</span>
                 </div>
                 <div id="post">
                     <a href="{Permalink}">
@@ -880,6 +994,12 @@
                         </p>
                     </div>
                 </div>
+                <div class="alltags">
+                    {block:HasTags}
+                      Tagged under
+                      {block:Tags}<a href="{TagURL}">#{Tag}</a>{/block:Tags}
+                    {/block:HasTags}
+                </div>
             {/block:Chat}
             <!-- Link -->
             {block:Link}
@@ -888,16 +1008,26 @@
                         {block:Date}{DayOfMonth} {Month} {Year}{/block:Date}
                     </a>
                     {block:IfEnableCommentCount}
-        				{block:IfDisqusShortname}
-						<a href="{Permalink}#disqus_thread">0 Comments</a>
-						{/block:IfDisqusShortname}
-					{/block:IfEnableCommentCount}
+                        {block:IfDisqusShortname}
+                              <a href="{Permalink}#disqus_thread">0 Comments</a>
+                        {/block:IfDisqusShortname}
+                    {/block:IfEnableCommentCount}
+                    {block:NoteCount}
+                        <span class="yesnote">{NoteCount} &#128077;</span>
+                    {/block:NoteCount}
+                    <span class="likeme">{LikeButton size="18"}</span>
                 </div>
                 <div id="post">
                     <div class="title"><a href="{URL}">{Name}</a></div>
                     {block:Description}
                         <div class="text">{Description}</div>
                     {/block:Description}
+                </div>
+                <div class="alltags">
+                    {block:HasTags}
+                      Tagged under
+                      {block:Tags}<a href="{TagURL}">#{Tag}</a>{/block:Tags}
+                    {/block:HasTags}
                 </div>
             {/block:Link}
             <!-- Post Footer -->
@@ -949,27 +1079,27 @@
     <!-- Disqus -->
     {block:IfDisqusShortname}
     <script>
-		var disqus_shortname = '{text:Disqus Shortname}';
-		(function () {
-			var s = document.createElement('script'); s.async = true;
-			s.src = 'http://' + disqus_shortname + '.disqus.com/count.js';
-			(document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
-		}());
-	</script>
-	{/block:IfDisqusShortname}
+    var disqus_shortname = '{text:Disqus Shortname}';
+    (function () {
+      var s = document.createElement('script'); s.async = true;
+      s.src = 'http://' + disqus_shortname + '.disqus.com/count.js';
+      (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
+    }());
+  </script>
+  {/block:IfDisqusShortname}
     <!-- Google Analytics -->
     {block:IfGoogleAnalyticsID}
     <script>
         var _gaq = _gaq || [];
-		_gaq.push(['_setAccount', '{text:Google Analytics ID}']);
-		_gaq.push(['_trackPageview']);
-		(function() {
-		var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-		ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-		var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-		})();
-	</script>
-	{/block:IfGoogleAnalyticsID}
+    _gaq.push(['_setAccount', '{text:Google Analytics ID}']);
+    _gaq.push(['_trackPageview']);
+    (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+    })();
+  </script>
+  {/block:IfGoogleAnalyticsID}
     <!-- Google Plusone -->
     <script type="text/javascript">
         (function() {


### PR DESCRIPTION
Thought the following features would be nice to add without disturbing the already setup responsive framework:
- Display the Like option on individual posts (i.e. visitor feedback is provided as soon as a post is read)
- Convert Notes display to custom thumb-ups for a more positive representation of blog content, useful for news/review blogs that wish to advertise user feedback in a slightly more moderated manner
- Resizable tag field for quicker in-blog search of topic-specific content

Would love feedback or further implementation tips. Merci!
